### PR TITLE
Fixes bug in reporting (html.escaping a variable that should always be an int)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ exclude = [
     ".tox",
     ".venv",
     "__pycache__",
+    "_version.py",
     "*.egg-info",
     "build",
     "dist",

--- a/src/bead_inspector/reporting.py
+++ b/src/bead_inspector/reporting.py
@@ -374,7 +374,7 @@ class ReportGenerator:
             f"{toc_descr}:</h3>{self.LINK_TO_TOC}"
             f"<ul><li>Data File: {expected_file_name}</li>"
             f"<li>Issue Level: {issue_level}</li>"
-            f"<li>Intended datatype: {html.escape(intended_type)}</li>"
+            f"<li>Intended datatype: {html.escape(str(intended_type))}</li>"
             "<li>Failing rows and their uncastable values:"
             f"{self._list_to_html_table(failing_rows)}</li>{trunc_note}"
             "<li>Total number of rows with uncastable values: "
@@ -675,7 +675,7 @@ class ReportGenerator:
         ) = self._unpack_core_issue_fields(issue)
         assert issue_type == "column_dtype_validation_misc"
         expected_file_name = f"{data_format}.csv"
-        row_number = html.escape(issue_details["row_number"])
+        row_number = issue_details["row_number"]
         column = html.escape(issue_details["column"])
         error_msg = html.escape(issue_details["error_msg"])
         error_type = html.escape(issue_details["error_type"])

--- a/tests/test_bead_inspector/test_reporting.py
+++ b/tests/test_bead_inspector/test_reporting.py
@@ -1,0 +1,48 @@
+import pytest
+
+from bead_inspector.validator import write_issues_to_json
+from bead_inspector import reporting
+
+
+@pytest.fixture
+def temp_dir(tmpdir_factory):
+    return tmpdir_factory.mktemp("data")
+
+
+@pytest.fixture
+def issue_log_file_with_column_dtype_validation_misc_issue(temp_dir):
+    test_error = TypeError()
+    issues = [
+        {
+            "data_format": "challenges",
+            "issue_type": "column_dtype_validation_misc",
+            "issue_level": "error",
+            "issue_details": {
+                "row_number": 2,
+                "column": "download_speed",
+                "error_msg": str(test_error),
+                "error_type": str(type(test_error)),
+            },
+        }
+    ]
+    file_path = temp_dir.join("column_dtype_validation_misc_20240722_142403.json")
+    write_issues_to_json(issues, file_path)
+    print(f"Wrote issue-log to {file_path} (is_file: {file_path.isfile()}")
+    return file_path
+
+
+def test__format_column_dtype_validation_misc_issue(
+    issue_log_file_with_column_dtype_validation_misc_issue,
+):
+    reporter = reporting.ReportGenerator(
+        issue_log_file_with_column_dtype_validation_misc_issue
+    )
+    dtype_misc_issues = [
+        iss
+        for iss in reporter.issues
+        if iss["issue_type"] == "column_dtype_validation_misc"
+    ]
+    toc_descr, html_output = reporter._format_column_dtype_validation_misc_issue(
+        issue=dtype_misc_issues[0],
+        issue_number=1,
+    )


### PR DESCRIPTION
Changes:
* Fixes a bug in reporting where `html.escape()` was passed an `int` instead of the expected string
* Adds a test module for covering functionality in the reporting.py module
    * Adds a fixture for an issue log file
    * implements a function to test that `ReportGenerator._format_column_dtype_validation_misc_issue()` runs without error with expected inputs (defined in the fixture).

published as version: bead-inspector 0.1.2.post1 