### PR TITLE
Handle extra column case more cleanly

### DIFF
--- a/src/bead_inspector/reporting.py
+++ b/src/bead_inspector/reporting.py
@@ -135,7 +135,12 @@ class ReportGenerator:
         self.issues = self._read_issues_from_file(self.issues_file_path)
         self.issues = sorted(
             self.issues,
-            key=lambda x: (x["issue_level"], x["data_format"], x["issue_type"]),
+            key=lambda x: (
+                x["issue_level"],
+                x["data_format"],
+                x["issue_sort_order"],
+                x["issue_type"],
+            ),
         )
 
     def _get_class_attributes(self, module_name: str, class_name: str) -> Dict:
@@ -359,7 +364,7 @@ class ReportGenerator:
             issue_level,
             issue_details,
         ) = self._unpack_core_issue_fields(issue)
-        assert issue_type == "03_column_dtype_validation"
+        assert issue_type == "column_dtype_validation"
         expected_file_name = f"{data_format}.csv"
         column = issue_details["column"]
         id_column = issue_details["id_column"]
@@ -484,7 +489,7 @@ class ReportGenerator:
             issue_level,
             issue_details,
         ) = self._unpack_core_issue_fields(issue)
-        assert issue_type == "00_column_name_validation"
+        assert issue_type == "column_name_validation"
         expected_file_name = f"{data_format}.csv"
         missing_cols = issue_details["columns_missing_from_file"]
         extra_cols = issue_details["extra_columns_in_file"]
@@ -529,7 +534,7 @@ class ReportGenerator:
             issue_level,
             issue_details,
         ) = self._unpack_core_issue_fields(issue)
-        assert issue_type == "01_column_order_validation"
+        assert issue_type == "column_order_validation"
         expected_file_name = f"{data_format}.csv"
         cols_out_of_order = issue_details["cols_out_of_order"]
         toc_descr = f"{expected_file_name} :: Incorrect column order"
@@ -553,7 +558,7 @@ class ReportGenerator:
             issue_level,
             issue_details,
         ) = self._unpack_core_issue_fields(issue)
-        assert issue_type == "02_unexpected_column_found"
+        assert issue_type == "unexpected_column_found"
         expected_file_name = f"{data_format}.csv"
         column = issue_details["column"]
         toc_descr = f"{expected_file_name} :: Unexpected column ('{column}') found"
@@ -741,22 +746,22 @@ class ReportGenerator:
             toc_line, formatted_issue = self._format_data_loading_failure_issue(
                 issue, issue_number
             )
-        elif issue_type == "00_column_name_validation":
+        elif issue_type == "column_name_validation":
             (
                 toc_line,
                 formatted_issue,
             ) = self._format_column_name_validation_issue(issue, issue_number)
-        elif issue_type == "01_column_order_validation":
+        elif issue_type == "column_order_validation":
             (
                 toc_line,
                 formatted_issue,
             ) = self._format_column_order_validation_issue(issue, issue_number)
-        elif issue_type == "02_unexpected_column_found":
+        elif issue_type == "unexpected_column_found":
             (
                 toc_line,
                 formatted_issue,
             ) = self._format_unexpected_column_found_issue(issue, issue_number)
-        elif issue_type == "03_column_dtype_validation":
+        elif issue_type == "column_dtype_validation":
             (
                 toc_line,
                 formatted_issue,

--- a/src/bead_inspector/reporting.py
+++ b/src/bead_inspector/reporting.py
@@ -359,7 +359,7 @@ class ReportGenerator:
             issue_level,
             issue_details,
         ) = self._unpack_core_issue_fields(issue)
-        assert issue_type == "column_dtype_validation"
+        assert issue_type == "03_column_dtype_validation"
         expected_file_name = f"{data_format}.csv"
         column = issue_details["column"]
         id_column = issue_details["id_column"]
@@ -484,7 +484,7 @@ class ReportGenerator:
             issue_level,
             issue_details,
         ) = self._unpack_core_issue_fields(issue)
-        assert issue_type == "column_name_validation"
+        assert issue_type == "00_column_name_validation"
         expected_file_name = f"{data_format}.csv"
         missing_cols = issue_details["columns_missing_from_file"]
         extra_cols = issue_details["extra_columns_in_file"]
@@ -529,7 +529,7 @@ class ReportGenerator:
             issue_level,
             issue_details,
         ) = self._unpack_core_issue_fields(issue)
-        assert issue_type == "column_order_validation"
+        assert issue_type == "01_column_order_validation"
         expected_file_name = f"{data_format}.csv"
         cols_out_of_order = issue_details["cols_out_of_order"]
         toc_descr = f"{expected_file_name} :: Incorrect column order"
@@ -544,7 +544,7 @@ class ReportGenerator:
         )
         return (toc_descr, html_output)
 
-    def _format_column_dtype_undefined_issue(
+    def _format_unexpected_column_found_issue(
         self, issue: Dict, issue_number: int
     ) -> Tuple[str, str]:
         (
@@ -553,18 +553,18 @@ class ReportGenerator:
             issue_level,
             issue_details,
         ) = self._unpack_core_issue_fields(issue)
-        assert issue_type == "column_dtype_undefined"
+        assert issue_type == "02_unexpected_column_found"
         expected_file_name = f"{data_format}.csv"
         column = issue_details["column"]
-        toc_descr = f"{expected_file_name} :: Undefined datatype for column '{column}'"
+        toc_descr = f"{expected_file_name} :: Unexpected column ('{column}') found"
         html_output = (
             f'<h3 id="issue-{issue_number}">{issue_number}. '
-            f"{toc_descr}</h3>{self.LINK_TO_TOC}\n"
+            f"{toc_descr}</h3>{self.LINK_TO_TOC}"
             f"<ul><li>Data File: {expected_file_name}</li>"
             f"<li>Issue Level: {issue_level}</li>"
-            "<li>Description: A datatype must be defined for every "
-            "column.</li>"
-            "</ul>\n"
+            "<li>Description: Columns must have the expected names and be in the "
+            "expected order.</li>"
+            "</ul>"
         )
         return (toc_descr, html_output)
 
@@ -741,22 +741,22 @@ class ReportGenerator:
             toc_line, formatted_issue = self._format_data_loading_failure_issue(
                 issue, issue_number
             )
-        elif issue_type == "column_name_validation":
+        elif issue_type == "00_column_name_validation":
             (
                 toc_line,
                 formatted_issue,
             ) = self._format_column_name_validation_issue(issue, issue_number)
-        elif issue_type == "column_order_validation":
+        elif issue_type == "01_column_order_validation":
             (
                 toc_line,
                 formatted_issue,
             ) = self._format_column_order_validation_issue(issue, issue_number)
-        elif issue_type == "column_dtype_undefined":
+        elif issue_type == "02_unexpected_column_found":
             (
                 toc_line,
                 formatted_issue,
-            ) = self._format_column_dtype_undefined_issue(issue, issue_number)
-        elif issue_type == "column_dtype_validation":
+            ) = self._format_unexpected_column_found_issue(issue, issue_number)
+        elif issue_type == "03_column_dtype_validation":
             (
                 toc_line,
                 formatted_issue,

--- a/src/bead_inspector/rules.py
+++ b/src/bead_inspector/rules.py
@@ -479,10 +479,10 @@ class CaiChallengeFRNGivenType(PostChallengeCaiFRNValidationGivenCAIType):
 
 class PostChallengeCaiLocationValidation:
     rule_descr = (
-        "Every CAI must have (at least) one of:"
-        "1. Lat/Long, Location ID"
-        "2. address_primary, city, and zip_code"
-        "3. location_id"
+        "Every CAI must have (at least) one complete non-null set of: "
+        "1. [Latitude and Longitude], "
+        "2. [address_primary, city, and zip_code], or "
+        "3. [location_id]"
     )
     short_descr = "Required location-identifying sets of values all missing"
     location_id_index: int = 6

--- a/src/bead_inspector/validator.py
+++ b/src/bead_inspector/validator.py
@@ -75,6 +75,7 @@ class SingleFileValidator:
                     "data_format": self.data_format,
                     "issue_type": "file_not_found",
                     "issue_level": "error",
+                    "issue_sort_order": 0,
                     "issue_details": {
                         "msg": f"Expected a CSV file in location {file_path}",
                     },
@@ -88,6 +89,7 @@ class SingleFileValidator:
                     "data_format": self.data_format,
                     "issue_type": "empty_file_error",
                     "issue_level": "error",
+                    "issue_sort_order": 0,
                     "issue_details": {},
                 }
             )
@@ -99,6 +101,7 @@ class SingleFileValidator:
                     "data_format": self.data_format,
                     "issue_type": "data_loading_failure",
                     "issue_level": "error",
+                    "issue_sort_order": 0,
                     "issue_details": {
                         "msg": "Encountered an unexpected error",
                         "error_msg": str(e),
@@ -125,8 +128,9 @@ class SingleFileValidator:
             self.issues.append(
                 {
                     "data_format": self.data_format,
-                    "issue_type": "00_column_name_validation",
+                    "issue_type": "column_name_validation",
                     "issue_level": "error",
+                    "issue_sort_order": 0,
                     "issue_details": {
                         "columns_missing_from_file": list(missing_cols),
                         "extra_columns_in_file": list(extra_cols),
@@ -155,8 +159,9 @@ class SingleFileValidator:
             self.issues.append(
                 {
                     "data_format": self.data_format,
-                    "issue_type": "01_column_order_validation",
+                    "issue_type": "column_order_validation",
                     "issue_level": "error",
+                    "issue_sort_order": 1,
                     "issue_details": {"cols_out_of_order": cols_out_of_order},
                 }
             )
@@ -175,8 +180,9 @@ class SingleFileValidator:
                 self.issues.append(
                     {
                         "data_format": self.data_format,
-                        "issue_type": "02_unexpected_column_found",
+                        "issue_type": "unexpected_column_found",
                         "issue_level": "error",
+                        "issue_sort_order": 2,
                         "issue_details": {"column": column},
                     }
                 )
@@ -222,6 +228,7 @@ class SingleFileValidator:
                             "data_format": self.data_format,
                             "issue_type": "column_dtype_validation_misc",
                             "issue_level": "error",
+                            "issue_sort_order": 4,
                             "issue_details": {
                                 "row_number": row[0],
                                 "column": column,
@@ -234,8 +241,9 @@ class SingleFileValidator:
                 self.issues.append(
                     {
                         "data_format": self.data_format,
-                        "issue_type": "03_column_dtype_validation",
+                        "issue_type": "column_dtype_validation",
                         "issue_level": "error",
+                        "issue_sort_order": 3,
                         "issue_details": {
                             "column": column,
                             "id_column": self.id_column,
@@ -252,6 +260,7 @@ class SingleFileValidator:
                         "data_format": self.data_format,
                         "issue_type": "enough_columns_validation",
                         "issue_level": "error",
+                        "issue_sort_order": 0,
                         "issue_details": {
                             "column": column,
                             "id_column": self.id_column,
@@ -305,6 +314,7 @@ class SingleFileValidator:
                         "data_format": self.data_format,
                         "issue_type": "required_column_not_null_validation",
                         "issue_level": "error",
+                        "issue_sort_order": 5,
                         "issue_details": {
                             "column": column,
                             "id_column": self.id_column,
@@ -347,6 +357,7 @@ class SingleFileValidator:
                             "data_format": self.data_format,
                             "issue_type": "column_contents_validation",
                             "issue_level": col_validation.issue_level,
+                            "issue_sort_order": 10,
                             "issue_details": {
                                 "column": column,
                                 "id_column": self.id_column,
@@ -364,6 +375,7 @@ class SingleFileValidator:
                         "data_format": self.data_format,
                         "issue_type": "column_missing",
                         "issue_level": col_validation.issue_level,
+                        "issue_sort_order": 1,
                         "issue_details": {
                             "column": column,
                         },
@@ -391,6 +403,7 @@ class SingleFileValidator:
                         "data_format": self.data_format,
                         "issue_type": "row_rule_validation",
                         "issue_level": row_validation.issue_level,
+                        "issue_sort_order": 15,
                         "issue_details": {
                             "rule_descr": row_validation.validation.rule_descr,
                             "id_column": self.id_column,
@@ -921,6 +934,7 @@ class BEADChallengeDataValidator:
                         "data_format": missing_data_format,
                         "issue_type": "missing_data_file",
                         "issue_level": "error",
+                        "issue_sort_order": 0,
                         "issue_details": {"data_dir": str(self.data_dir)},
                     }
                 )
@@ -986,6 +1000,7 @@ class BEADChallengeDataValidator:
                     "data_format": "challenges",
                     "issue_type": "multi_file_validation",
                     "issue_level": "error",
+                    "issue_sort_order": 20,
                     "issue_details": {
                         "other_data_format": "challengers",
                         "short_msg": (
@@ -1017,6 +1032,7 @@ class BEADChallengeDataValidator:
                     "data_format": "challenges",
                     "issue_type": "multi_file_validation",
                     "issue_level": "error",
+                    "issue_sort_order": 20,
                     "issue_details": {
                         "other_data_format": "challengers",
                         "short_msg": (
@@ -1048,6 +1064,7 @@ class BEADChallengeDataValidator:
                     "data_format": "cai_challenges",
                     "issue_type": "multi_file_validation",
                     "issue_level": "error",
+                    "issue_sort_order": 20,
                     "issue_details": {
                         "other_data_format": "challengers",
                         "short_msg": (
@@ -1079,6 +1096,7 @@ class BEADChallengeDataValidator:
                     "data_format": "cai_challenges",
                     "issue_type": "multi_file_validation",
                     "issue_level": "error",
+                    "issue_sort_order": 20,
                     "issue_details": {
                         "other_data_format": "challengers",
                         "short_msg": (
@@ -1099,7 +1117,13 @@ class BEADChallengeDataValidator:
             print(self.issues)
         else:
             self.issues = sorted(
-                self.issues, key=lambda x: (x["issue_level"], x["issue_type"])
+                self.issues,
+                key=lambda x: (
+                    x["issue_level"],
+                    x["data_format"],
+                    x["issue_sort_order"],
+                    x["issue_type"],
+                ),
             )
             write_issues_to_json(issues=self.issues, file_path=self.log_path)
         print(f"Number of issues (or types of issues) found: {len(self.issues)}")

--- a/tests/test_bead_inspector/test_reporting.py
+++ b/tests/test_bead_inspector/test_reporting.py
@@ -17,6 +17,7 @@ def issue_log_file_with_column_dtype_validation_misc_issue(temp_dir):
             "data_format": "challenges",
             "issue_type": "column_dtype_validation_misc",
             "issue_level": "error",
+            "issue_sort_order": 4,
             "issue_details": {
                 "row_number": 2,
                 "column": "download_speed",

--- a/tests/test_bead_inspector/test_validator.py
+++ b/tests/test_bead_inspector/test_validator.py
@@ -419,7 +419,98 @@ def test_BEADChallengeDataValidator_with_files_with_extra_trailing_columns(
         i for i in bcdv.issues if i["issue_type"] == "column_dtype_validation_misc"
     ]
     col_name_issues = [
-        i for i in bcdv.issues if i["issue_type"] == "00_column_name_validation"
+        i for i in bcdv.issues if i["issue_type"] == "column_name_validation"
+    ]
+    assert len(misc_issues) == 0
+    assert len(col_name_issues) == 5
+
+
+@pytest.fixture
+def challenges_file_with_extra_non_trailing_columns(temp_dir):
+    csv_content = (
+        "pk_column,content_hash,challenge,challenge_type,challenger,challenge_date,"
+        "rebuttal_date,resolution_date,disposition,provider_id,technology,location_id,"
+        "unit,reason_code,evidence_file_id,response_file_id,resolution,"
+        "advertised_download_speed,download_speed,advertised_upload_speed,"
+        "upload_speed,latency\n"
+        ",,,,,,,,,,,,,,,,,,,,,\n"
+    )
+    file_path = temp_dir.join("challenges.csv")
+    csv_lines = [line.split(",") for line in csv_content.split("\n") if line]
+    create_csv_file(file_path, csv_lines)
+    return file_path
+
+
+@pytest.fixture
+def challengers_file_with_extra_non_trailing_columns(temp_dir):
+    csv_content = (
+        "pk_column,content_hash,challenger,category,organization,webpage,provider_id,"
+        "contact_name,contact_email,contact_phone\n"
+        ",,,,,,,,,\n"
+    )
+    file_path = temp_dir.join("challengers.csv")
+    csv_lines = [line.split(",") for line in csv_content.split("\n") if line]
+    create_csv_file(file_path, csv_lines)
+    return file_path
+
+
+@pytest.fixture
+def post_challenge_cai_file_with_extra_non_trailing_columns(temp_dir):
+    csv_content = (
+        "pk_column,content_hash,type,entity_name,entity_number,CMS number,frn,"
+        "location_id,address_primary,city,state,zip_code,longitude,latitude,"
+        "explanation,need,availability\n"
+        ",,,,,,,,,,,,,,,,\n"
+    )
+    file_path = temp_dir.join("post_challenge_cai.csv")
+    csv_lines = [line.split(",") for line in csv_content.split("\n") if line]
+    create_csv_file(file_path, csv_lines)
+    return file_path
+
+
+@pytest.fixture
+def cai_file_with_extra_non_trailing_columns(temp_dir):
+    csv_content = (
+        "pk_column,content_hash,type,entity_name,entity_number,CMS number,frn,"
+        "location_id,address_primary,city,state,zip_code,longitude,latitude,"
+        "explanation,need,availability\n"
+        ",,,,,,,,,,,,,,,,\n"
+    )
+    file_path = temp_dir.join("cai.csv")
+    csv_lines = [line.split(",") for line in csv_content.split("\n") if line]
+    create_csv_file(file_path, csv_lines)
+    return file_path
+
+
+@pytest.fixture
+def cai_challenges_file_with_extra_non_trailing_columns(temp_dir):
+    csv_content = (
+        "pk_column,content_hash,challenge,challenge_type,challenger,category_code,"
+        "disposition,challenge_explanation,type,entity_name,entity_number,CMS number,"
+        "frn,location_id,address_primary,city,state,zip_code,longitude,latitude,"
+        "explanation,need,availability\n"
+        ",,,,,,,,,,,,,,,,,,,,,,\n"
+    )
+    file_path = temp_dir.join("cai_challenges.csv")
+    csv_lines = [line.split(",") for line in csv_content.split("\n") if line]
+    create_csv_file(file_path, csv_lines)
+    return file_path
+
+
+def test_BEADChallengeDataValidator_with_files_with_extra_non_trailing_columns(
+    temp_dir,
+    challengers_file_with_extra_non_trailing_columns,
+    challenges_file_with_extra_non_trailing_columns,
+    cai_file_with_extra_non_trailing_columns,
+    cai_challenges_file_with_extra_non_trailing_columns,
+    post_challenge_cai_file_with_extra_non_trailing_columns,
+):
+    bcdv = validator.BEADChallengeDataValidator(temp_dir)
+    misc_issues = [
+        i for i in bcdv.issues if i["issue_type"] == "column_dtype_validation_misc"
+    ]
+    col_name_issues = [
+        i for i in bcdv.issues if i["issue_type"] == "column_name_validation"
     ]
     assert len(misc_issues) == 0
     assert len(col_name_issues) == 5
@@ -676,7 +767,7 @@ def test_challenger__column_names():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "00_column_name_validation"
+            if i["issue_type"] == "column_name_validation"
         ]
         assert len(test_issues) == 1
         assert list(test_issues[0].keys()) == [
@@ -718,7 +809,7 @@ def test_challenger__column_order():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "01_column_order_validation"
+            if i["issue_type"] == "column_order_validation"
         ]
         assert len(test_issues) == 1
         cols_out_of_order = test_issues[0]["cols_out_of_order"]
@@ -1081,7 +1172,7 @@ def test_challenges__column_names():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "00_column_name_validation"
+            if i["issue_type"] == "column_name_validation"
         ]
         assert len(test_issues) == 1
         assert list(test_issues[0].keys()) == [
@@ -1113,7 +1204,7 @@ def test_challenges__column_order():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "01_column_order_validation"
+            if i["issue_type"] == "column_order_validation"
         ]
         assert len(test_issues) == len(file_col_names_in_wrong_place)
         assert set(el["column_name_in_file"] for el in test_issues) == set(
@@ -1156,7 +1247,7 @@ def test_challenges__column_order():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "01_column_order_validation"
+            if i["issue_type"] == "column_order_validation"
         ]
         assert len(test_issues) == 1
         cols_out_of_order = test_issues[0]["cols_out_of_order"]
@@ -1225,7 +1316,7 @@ def test_challenges_column_dtypes__technology():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -1263,7 +1354,7 @@ def test_challenges_column_dtypes__location_id():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -1301,7 +1392,7 @@ def test_challenges_column_dtypes__advertised_download_speed():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -1339,7 +1430,7 @@ def test_challenges_column_dtypes__download_speed():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -1377,7 +1468,7 @@ def test_challenges_column_dtypes__advertised_upload_speed():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -1415,7 +1506,7 @@ def test_challenges_column_dtypes__upload_speed():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -1453,7 +1544,7 @@ def test_challenges_column_dtypes__latency():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -2947,7 +3038,7 @@ def test_cai__column_names():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "00_column_name_validation"
+            if i["issue_type"] == "column_name_validation"
         ]
         assert len(test_issues) == 1
         assert list(test_issues[0].keys()) == [
@@ -2986,7 +3077,7 @@ def test_cai__column_order():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "01_column_order_validation"
+            if i["issue_type"] == "column_order_validation"
         ]
         assert len(test_issues) == 1
         cols_out_of_order = test_issues[0]["cols_out_of_order"]
@@ -3043,7 +3134,7 @@ def test_cai_column_dtypes__entity_number():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -3077,7 +3168,7 @@ def test_cai_column_dtypes__location_id():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -3112,7 +3203,7 @@ def test_cai_column_dtypes__need():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -3147,7 +3238,7 @@ def test_cai_column_dtypes__availability():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -3761,7 +3852,7 @@ def test_cai_challenges__column_names():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "00_column_name_validation"
+            if i["issue_type"] == "column_name_validation"
         ]
         assert len(test_issues) == 1
         assert list(test_issues[0].keys()) == [
@@ -3805,7 +3896,7 @@ def test_cai_challenges__column_order():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "01_column_order_validation"
+            if i["issue_type"] == "column_order_validation"
         ]
 
         assert len(test_issues) == 1
@@ -3866,7 +3957,7 @@ def test_cai_challenges_column_dtypes__entity_number():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -3902,7 +3993,7 @@ def test_cai_challenges_column_dtypes__location_id():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -3940,7 +4031,7 @@ def test_cai_challenges_column_dtypes__need():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -3978,7 +4069,7 @@ def test_cai_challenges_column_dtypes__availability():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -4715,7 +4806,7 @@ def test_post_challenge_location__column_names():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "00_column_name_validation"
+            if i["issue_type"] == "column_name_validation"
         ]
         assert len(test_issues) == 1
         assert list(test_issues[0].keys()) == [
@@ -4745,7 +4836,7 @@ def test_post_challenge_location__column_order():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "01_column_order_validation"
+            if i["issue_type"] == "column_order_validation"
         ]
         assert len(test_issues) == 1
         cols_out_of_order = test_issues[0]["cols_out_of_order"]
@@ -4801,7 +4892,7 @@ def test_post_challenge_location_column_dtypes__location_id():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -4834,7 +4925,7 @@ def test_post_challenge_location_column_dtypes__classification():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -4939,7 +5030,7 @@ def test_post_challenge_cai__column_names():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "00_column_name_validation"
+            if i["issue_type"] == "column_name_validation"
         ]
         assert len(test_issues) == 1
         assert list(test_issues[0].keys()) == [
@@ -4986,7 +5077,7 @@ def test_post_challenge_cai__column_order():
         test_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "01_column_order_validation"
+            if i["issue_type"] == "column_order_validation"
         ]
         assert len(test_issues) == 1
         cols_out_of_order = test_issues[0]["cols_out_of_order"]
@@ -5043,7 +5134,7 @@ def test_post_challenge_cai_column_dtypes__entity_number():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -5077,7 +5168,7 @@ def test_post_challenge_cai_column_dtypes__location_id():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -5112,7 +5203,7 @@ def test_post_challenge_cai_column_dtypes__need():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -5147,7 +5238,7 @@ def test_post_challenge_cai_column_dtypes__availability():
         col_dtype_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -5808,7 +5899,7 @@ def test_unserved_column_dtypes__location_id():
         col_contents_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]
@@ -5884,7 +5975,7 @@ def test_underserved_column_dtypes__location_id():
         col_contents_issues = [
             i["issue_details"]
             for i in issues
-            if i["issue_type"] == "03_column_dtype_validation"
+            if i["issue_type"] == "column_dtype_validation"
         ]
         row_fails = [
             i["failing_rows_and_values"]


### PR DESCRIPTION
If a file has an unexpected column, there won't be an expected dtype for that column. This was causing `SingleFileValidator.validate_column_types()` to throw `TypeError`s when a file had extra columns.

Changes:
* Sets the `valid_column_type` to `str` when there isn't a defined dtype for a column.
* Adds a `issue_sort_order` field to issues to control their ordering in the output report (to nudge users to fix certain issues first).
* Refactors reporting of unexpected columns
    * Calls these out more explicitly (replacing the `column_dtype_undefined` issue type with `unexpected_column_found`, as users aren't given any easy way to define `column_dtypes` and fixing column order and set will fix a lot of other issues.
* Modified logic of `required_column_not_null_validation` to allow nullability of unexpected columns